### PR TITLE
#66: Fixed configuration being used on .gitattributes to the end of line format

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-text eol=auto
+* text=auto


### PR DESCRIPTION
I was by accident mixing up two configurations in one, which was invalid.