### PR TITLE
#80: Added two new quantities from UCUM

### DIFF
--- a/quantity/src/main/java/systems/uom/quantity/Acidity.java
+++ b/quantity/src/main/java/systems/uom/quantity/Acidity.java
@@ -1,0 +1,38 @@
+/*
+ *  Unit-API - Units of Measurement API for Java
+ *  Copyright (c) 2005-2017, Jean-Marie Dautelle, Werner Keil, V2COM.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JSR-363 nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package systems.uom.quantity;
+
+import javax.measure.Quantity;
+
+/**
+ * Measure of acidity.
+ * The usual unit for this quantity is represented by <code>PH</code>.
+ * 
+ * @author Magno N. A. Cruz
+ * @version 0.7, Apr 04, 2017
+ */
+public interface Acidity extends Quantity<Acidity> {
+}

--- a/quantity/src/main/java/systems/uom/quantity/Concentration.java
+++ b/quantity/src/main/java/systems/uom/quantity/Concentration.java
@@ -1,0 +1,40 @@
+/*
+ *  Unit-API - Units of Measurement API for Java
+ *  Copyright (c) 2005-2017, Jean-Marie Dautelle, Werner Keil, V2COM.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JSR-363 nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package systems.uom.quantity;
+
+import javax.measure.Quantity;
+
+/**
+ * Concentration of a {@link Quantity}.
+ * 
+ * @author Magno N. A. Cruz
+ * @version 0.7, Apr 04, 2017
+ * @see <a href="https://en.wikipedia.org/wiki/Concentration">Wikipedia: Concentration</a>
+ * @see <a href="http://goldbook.iupac.org/maps/C01222.3.map.html">IUPAC Gold Book: Interactive Link Map - Concentration</a>
+ * @see <a href="https://iupac.org">IUPAC</a>
+ */
+public interface Concentration<Q extends Quantity<Q>> extends Quantity<Concentration<Q>> {
+}

--- a/ucum-java8/src/main/java/systems/uom/ucum/UCUM.java
+++ b/ucum-java8/src/main/java/systems/uom/ucum/UCUM.java
@@ -27,19 +27,8 @@ package systems.uom.ucum;
 
 import static tec.uom.se.unit.MetricPrefix.*;
 import static tec.uom.se.AbstractUnit.ONE;
-import si.uom.quantity.Action;
-import si.uom.quantity.DynamicViscosity;
-import si.uom.quantity.ElectricPermittivity;
-import si.uom.quantity.IonizingRadiation;
-import si.uom.quantity.KinematicViscosity;
-import si.uom.quantity.Luminance;
-import si.uom.quantity.MagneticFieldStrength;
-import si.uom.quantity.MagneticPermeability;
-import si.uom.quantity.MagnetomotiveForce;
-import si.uom.quantity.WaveNumber;
-import systems.uom.quantity.Information;
-import systems.uom.quantity.InformationRate;
-import systems.uom.quantity.Level;
+import si.uom.quantity.*;
+import systems.uom.quantity.*;
 import si.uom.SI;
 import tec.uom.se.*;
 import tec.uom.se.format.SimpleUnitFormat;
@@ -750,13 +739,10 @@ public final class UCUM extends AbstractSystemOfUnits {
     // public static final Unit EQUIVALENTS = addUnit(MOLE);
     // public static final Unit OSMOLE = addUnit(MOLE);
 
-    // public static final Unit<Dimensionless> PH =
-    // addUnit(MOLE.divide(LITER).transform(new
-    // LogConverter(10)).multiply(-1).asType(Dimensionless.class));
+    // public static final Unit<Acidity> PH = addUnit(MOLE.divide(LITER).transform(new LogConverter(10)).multiply(-1).asType(Acidity.class));
 
-    // TODO create the unit (MassConcentration) for GRAM_PERCENT
-    // public static final Unit GRAM_PERCENT =
-    // addUnit(GRAM.divide(DECI(LITER)));
+    // @SuppressWarnings("unchecked")
+    // public static final Unit<Concentration<Mass>> GRAM_PERCENT = addUnit(GRAM.divide(DECI(LITER)).asType(Concentration.class));
 
     // public static final Unit SVEDBERG = addUnit(SECOND.multiply(1E-13));
 

--- a/ucum-java8/src/main/java/systems/uom/ucum/format/UCUMFormat.java
+++ b/ucum-java8/src/main/java/systems/uom/ucum/format/UCUMFormat.java
@@ -200,7 +200,7 @@ public abstract class UCUMFormat extends AbstractUnitFormat {
         final boolean printSeparator = !parentUnit.equals(ONE);
 
         format(parentUnit, temp);
-        formatConverter(converter, printSeparator, temp); // TODO make it compatible with prefixes variants
+        formatConverter(converter, printSeparator, temp);
 
         symbol = temp;
 	} else if (unit.getBaseUnits() != null) {

--- a/ucum-java8/src/main/resources/systems/uom/ucum/format/UCUMFormat_CI.properties
+++ b/ucum-java8/src/main/resources/systems/uom/ucum/format/UCUMFormat_CI.properties
@@ -253,6 +253,8 @@ systems.uom.ucum.UCUM.CARAT_GOLD=[CAR_AU]
 systems.uom.ucum.UCUM.BIT=BIT
 systems.uom.ucum.UCUM.BYTE=BY
 systems.uom.ucum.UCUM.BAUD=Bd
+systems.uom.ucum.UCUM.PH=[PH]
+systems.uom.ucum.UCUM.GRAM_PERCENT=G%
 #systems.uom.ucum.UCUM.FRAMES_PER_SECOND=fps
 
 # Common Units (defined by implementation)

--- a/ucum-java8/src/main/resources/systems/uom/ucum/format/UCUMFormat_CS.properties
+++ b/ucum-java8/src/main/resources/systems/uom/ucum/format/UCUMFormat_CS.properties
@@ -255,6 +255,8 @@ systems.uom.ucum.UCUM.CARAT_GOLD=[car_Au]
 systems.uom.ucum.UCUM.BIT=bit
 systems.uom.ucum.UCUM.BYTE=By
 systems.uom.ucum.UCUM.BAUD=Bd
+systems.uom.ucum.UCUM.PH=[pH]
+systems.uom.ucum.UCUM.GRAM_PERCENT=g%
 #systems.uom.ucum.UCUM.FRAMES_PER_SECOND=fps
 
 # Common Units (defined by implementation)

--- a/ucum-java8/src/main/resources/systems/uom/ucum/format/UCUMFormat_Print.properties
+++ b/ucum-java8/src/main/resources/systems/uom/ucum/format/UCUMFormat_Print.properties
@@ -253,6 +253,8 @@ systems.uom.ucum.UCUM.CARAT_GOLD=ct_Au
 systems.uom.ucum.UCUM.BIT=bit
 systems.uom.ucum.UCUM.BYTE=B
 systems.uom.ucum.UCUM.BAUD=Bd
+systems.uom.ucum.UCUM.PH=pH
+systems.uom.ucum.UCUM.GRAM_PERCENT=g%
 #systems.uom.ucum.UCUM.FRAMES_PER_SECOND=fps
 
 # Common Units (defined by implementation)


### PR DESCRIPTION
I added those quantities but I just couldn't use them because of a conflict on the versions, the current UCUM project is using the version `0.6` of `systems-quantity` and for some reason I can't change that, I don't know if it's my machine or the way that it's configured.. But without the version issues it's pretty functional, and we must just delete the comment chars and they'll be ready to work.