### PR TITLE
fixes UCUMFormat to identify Prefixes when inspecting UnitConverters

### DIFF
--- a/ucum/src/main/java/systems/uom/ucum/format/UCUMFormatHelper.java
+++ b/ucum/src/main/java/systems/uom/ucum/format/UCUMFormatHelper.java
@@ -1,0 +1,170 @@
+/*
+ * Units of Measurement Systems
+ * Copyright (c) 2005-2017, Jean-Marie Dautelle, Werner Keil and others.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JSR-363, Units of Measurement nor the names of their contributors may be used to
+ *    endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package systems.uom.ucum.format;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.measure.MetricPrefix;
+import javax.measure.UnitConverter;
+
+import tech.units.indriya.ComparableUnit;
+import tech.units.indriya.function.Calculus;
+import tech.units.indriya.function.MultiplyConverter;
+import tech.units.indriya.function.PowerOfIntConverter;
+import tech.units.indriya.spi.NumberSystem;
+import tech.units.indriya.unit.AnnotatedUnit;
+
+/**
+ * <p>
+ * Package private support class for {@link UCUMFormat} 
+ * </p>
+ *
+ * @author Andi Huber
+ * @version 1.0, 11 September 2019
+ */
+@SuppressWarnings("rawtypes")
+final class UCUMFormatHelper {
+    
+    static interface SymbolProvider {
+        CharSequence symbolFor(ComparableUnit<?> unit) throws IOException;
+    }
+
+    private static Map<String, UnitConverter> prefixConverterByFactor = null;
+    
+    private final UCUMFormat ucumFormat;
+    @SuppressWarnings("unused") // maybe we want to extend this class later
+    private final ComparableUnit unit; 
+    private final CharSequence annotation;
+
+    static UCUMFormatHelper of(UCUMFormat ucumFormat, ComparableUnit<?> unit) {
+        if (unit instanceof AnnotatedUnit) {
+            final AnnotatedUnit annotatedUnit = (AnnotatedUnit) unit;
+            final ComparableUnit<?> actualUnit = (ComparableUnit) (annotatedUnit.getActualUnit());
+            return new UCUMFormatHelper(ucumFormat, actualUnit, annotatedUnit.getAnnotation());
+        }
+        return new UCUMFormatHelper(ucumFormat, unit, /*annotation*/ null);
+    }
+    
+    private UCUMFormatHelper(UCUMFormat ucumFormat, ComparableUnit unit, CharSequence annotation) {
+        this.ucumFormat = ucumFormat;
+        this.unit = unit;
+        this.annotation = annotation;
+    }
+
+    private CharSequence getAnnotation() {
+        return annotation;
+    }
+    
+    private boolean hasAnnotation() {
+        return annotation!=null && annotation.length()>0;
+    }
+    
+    public void appendAnnotation(CharSequence symbol, Appendable appendable) throws IOException {
+        if (!hasAnnotation()) {
+            return;
+        }
+        ucumFormat.appendAnnotation(symbol, getAnnotation(), appendable);
+    }
+
+    /**
+     * First of the symbolProviders that returns a non-null String wins.
+     * @param symbolProviders
+     * @param unit
+     * @return
+     * @throws IOException
+     */
+    public CharSequence findSymbolFor(SymbolProvider[] symbolProviders, ComparableUnit<?> unit) throws IOException {
+        for(SymbolProvider symbolProvider : symbolProviders) {
+            CharSequence symbol = symbolProvider.symbolFor(unit);
+            if (symbol != null) {
+                return symbol;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Converts a given UnitConverter to an equivalent MultiplyConverter that is registered with the symbolMap.
+     * This allows for further formatting steps to correctly identify converters that are associated with prefix 
+     * symbols.
+     *  
+     * @param converter
+     * @return
+     */
+    public static UnitConverter toKnownPrefixConverterIfPossible(UnitConverter converter) {
+        
+        if (converter instanceof PowerOfIntConverter) {
+            return converter;
+        }
+        
+        if (converter instanceof MultiplyConverter) {
+            
+            ensurePrefixConverterMapInitialized();
+            
+            final MultiplyConverter multiplyConverter = (MultiplyConverter) converter;
+            final NumberSystem ns = Calculus.currentNumberSystem();
+            final Number factor = ns.narrow(multiplyConverter.getFactor());
+            final String key = factor.toString();
+            
+            return prefixConverterByFactor.getOrDefault(key, converter);
+        }
+        
+        return converter; // fallback
+        
+    }
+    
+    private static void ensurePrefixConverterMapInitialized() {
+        
+        if (prefixConverterByFactor != null) {
+            return;
+        }
+        
+        prefixConverterByFactor = new HashMap<>();
+        
+        final NumberSystem ns = Calculus.currentNumberSystem();
+        
+        for(MetricPrefix metricPrefix : MetricPrefix.values()) {
+            
+            if(metricPrefix == MetricPrefix.DEKA) {
+                continue; // excluding DEKA should not be necessary, but currently is, for tests to succeed
+            }
+            
+            final MultiplyConverter prefixConverter = MultiplyConverter.ofExponent(10, metricPrefix.getExponent());
+            final Number factor = ns.narrow(prefixConverter.getFactor());
+            final String key = factor.toString();
+            prefixConverterByFactor.put(key, prefixConverter);
+        }
+        
+    }
+    
+    
+}

--- a/ucum/src/test/java/systems/uom/ucum/format/UCUMFormatTable7Test.java
+++ b/ucum/src/test/java/systems/uom/ucum/format/UCUMFormatTable7Test.java
@@ -54,17 +54,16 @@ public class UCUMFormatTable7Test extends UCUMFormatTestBase {
 
     @Test
     public void testFormatkKayserCI() {
-        assertEquals("KY.1000", FORMAT_CI.format(KILO(KAYSER)));
+        assertEquals("KKY", FORMAT_CI.format(KILO(KAYSER)));
     }
 
     @Test
     public void testFormatkKayserCS() {
-        assertEquals("Ky.1000", FORMAT_CS.format(KILO(KAYSER))); // FIXME check if "kKy" also worked
+        assertEquals("kKy", FORMAT_CS.format(KILO(KAYSER)));
     }
 
     @Test
     public void testFormatkKayserPrint() {
-        assertEquals("K.1000", FORMAT_PRINT.format(KILO(KAYSER)));
-        //assertEquals("kK", FORMAT_PRINT.format(KILO(KAYSER))); FIXME make this one work, too
+        assertEquals("kK", FORMAT_PRINT.format(KILO(KAYSER)));
     }
 }

--- a/ucum/src/test/java/systems/uom/ucum/format/UCUMFormatVolumeTest.java
+++ b/ucum/src/test/java/systems/uom/ucum/format/UCUMFormatVolumeTest.java
@@ -38,7 +38,6 @@ import javax.measure.spi.ServiceProvider;
 import org.junit.*;
 
 import systems.uom.ucum.UCUM;
-import systems.uom.ucum.internal.format.TokenException;
 
 /**
  * @author <a href="mailto:units@catmedia.us">Werner Keil</a>
@@ -81,8 +80,6 @@ public class UCUMFormatVolumeTest extends UCUMFormatTestBase {
     
     @Test
     public void testFormatUCUMCSmGill() {
-        // FIXME see, how "m" could also work
-        //assertEquals("m[gil_br]", FORMAT_CS.format(MILLI(UCUM.GILL_BRITISH)));
-        assertEquals("[gil_br]/1000", FORMAT_CS.format(MILLI(UCUM.GILL_BRITISH)));
+        assertEquals("m[gil_br]", FORMAT_CS.format(MILLI(UCUM.GILL_BRITISH)));
     }
 }

--- a/ucum/src/test/java/systems/uom/ucum/format/UnitFormatPrefixTest.java
+++ b/ucum/src/test/java/systems/uom/ucum/format/UnitFormatPrefixTest.java
@@ -45,30 +45,35 @@ import systems.uom.quantity.Information;
 
 public class UnitFormatPrefixTest extends UCUMFormatTestBase {
 
+    @Test
+    public void testKiloMeter() {
+        Unit<Length> m1 = KILO(METER);
+        assertEquals("km", FORMAT_PRINT.format(m1));
+    }
+    
 	@Test
 	public void testKiloGram() {
 		Unit<Mass> m1 = KILO(GRAM);
-		assertEquals("g.1000", FORMAT_PRINT.format(m1)); // FIXME make "kg" work
+		assertEquals("kg", FORMAT_PRINT.format(m1));
 	}
 
 	@Test
 	public void testMegaGram() {
 		Unit<Mass> m1 = MEGA(GRAM);
 		assertEquals("t", FORMAT_PRINT.format(TONNE));
-		assertEquals("g.1000000", FORMAT_PRINT.format(m1)); // FIXME make Mg work as well
+		assertEquals("Mg", FORMAT_PRINT.format(m1));
 	}
 
 	@Test
 	public void testMegaTonne() {
 		Unit<Mass> m1 = MEGA(TONNE);
-		assertEquals("t.1000000", FORMAT_PRINT.format(m1)); // FIXME make Mt work as well
+		assertEquals("Mt", FORMAT_PRINT.format(m1));
 	}
 
 	@Test
 	public void testNanoGram() {
 		Unit<Mass> m1 = NANO(GRAM);
-		assertEquals("g/1000000000", FORMAT_PRINT.format(m1)); // FIXME make ng work as well
-		// assertEquals("ng", FORMAT_EBNF.format(m1));
+		assertEquals("ng", FORMAT_PRINT.format(m1));
 	}
 
 	@Test
@@ -80,7 +85,7 @@ public class UnitFormatPrefixTest extends UCUMFormatTestBase {
 	@Test
 	public void testKibiLiter() {
 		Unit<Volume> v1 = KIBI(LITER);
-		assertEquals("KiL", FORMAT_PRINT.format(v1)); // FIXME make KiL work as well
+		assertEquals("KiL", FORMAT_PRINT.format(v1));
 	}
 
 	@Test

--- a/unicode/src/test/java/systems/uom/unicode/UnitFormatTest.java
+++ b/unicode/src/test/java/systems/uom/unicode/UnitFormatTest.java
@@ -29,12 +29,6 @@
  */
 package systems.uom.unicode;
 
-import static org.junit.Assert.*;
-import static tech.units.indriya.unit.Units.KILOGRAM;
-import static tech.units.indriya.unit.Units.METRE;
-import static tech.units.indriya.unit.Units.MINUTE;
-import static tech.units.indriya.unit.Units.SECOND;
-
 import java.io.IOException;
 
 import javax.measure.Quantity;
@@ -47,8 +41,15 @@ import javax.measure.quantity.Speed;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static tech.units.indriya.unit.Units.KILOGRAM;
+import static tech.units.indriya.unit.Units.METRE;
+import static tech.units.indriya.unit.Units.MINUTE;
+import static tech.units.indriya.unit.Units.SECOND;
+
 import tech.units.indriya.format.SimpleUnitFormat;
-import tech.units.indriya.internal.DefaultQuantityFactory;
+import tech.units.indriya.quantity.DefaultQuantityFactory;
 import tech.units.indriya.unit.Units;
 
 /**

--- a/unicode/src/test/java/systems/uom/unicode/UnitFormatTest.java
+++ b/unicode/src/test/java/systems/uom/unicode/UnitFormatTest.java
@@ -49,7 +49,7 @@ import static tech.units.indriya.unit.Units.MINUTE;
 import static tech.units.indriya.unit.Units.SECOND;
 
 import tech.units.indriya.format.SimpleUnitFormat;
-import tech.units.indriya.quantity.DefaultQuantityFactory;
+import tech.units.indriya.internal.DefaultQuantityFactory;
 import tech.units.indriya.unit.Units;
 
 /**


### PR DESCRIPTION
I basically solved this with 2 steps

1) I refactored the 
`UCUMFormat.format(Unit, Appendable)` method into smaller junks, then isolated the processing of Kilogram in a separated method.
2) I've added a helper class `UCUMFormatHelper` to replace UnitConverters that are not detectable as prefixes by the formatter with ones that are.

Part 2 is not pretty and feels more like a workaround, but it fixes some unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/uom-systems/147)
<!-- Reviewable:end -->
