### PR TITLE
#162 Units with higher powers in denominator cannot be formatted with UCUM formatter

### DIFF
--- a/ucum/src/main/java/systems/uom/ucum/format/UCUMFormat.java
+++ b/ucum/src/main/java/systems/uom/ucum/format/UCUMFormat.java
@@ -246,7 +246,7 @@ public abstract class UCUMFormat extends AbstractUnitFormat {
             		// add individual unit string
             		format(u.getKey(),app);
             		// add power number if abs greater than 1
-                	if (Math.abs(u.getValue()) < -1){
+                	if (u.getValue() < -1){
                 		app.append(-u.getValue());
                 	}
                 	// if there is more than one denominator unit and this is the last, add close parenthesis

--- a/ucum/src/test/java/systems/uom/ucum/format/UCUMFormatTable4Test.java
+++ b/ucum/src/test/java/systems/uom/ucum/format/UCUMFormatTable4Test.java
@@ -61,6 +61,8 @@ import javax.measure.quantity.Frequency;
 
 import org.junit.*;
 
+import systems.uom.ucum.UCUM;
+
 /**
  * @author <a href="mailto:units@catmedia.us">Werner Keil</a>
  *
@@ -402,5 +404,12 @@ public class UCUMFormatTable4Test extends UCUMFormatTestBase {
 	assertEquals("The KILO prefix didn't work with a product unit", "km/s",
 		format.format(KILO(METER).divide(SECOND)));
     }
+    
+	@Test
+	public void testNewton(){
+		final UnitFormat format = UCUMFormat.getInstance(PRINT);
+		Unit newton = KILO(UCUM.GRAM).multiply(UCUM.METER).divide(UCUM.SECOND).divide(UCUM.SECOND);
+		assertEquals("g.1000.m/s2", format.format(newton));
+	}
 
 }


### PR DESCRIPTION
Fix power not being appended to units with denominators with power greater than one in UCUMFormat.java

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/uom-systems/164)
<!-- Reviewable:end -->
