### PR TITLE
fix: expose missing public modifiers in Imperial units

### DIFF
--- a/common/src/main/java/systems/uom/common/Imperial.java
+++ b/common/src/main/java/systems/uom/common/Imperial.java
@@ -198,7 +198,7 @@ public final class Imperial extends AbstractSystemOfUnits {
      * A unit of volume equal to <code>1 / 160 {@link #GALLON_UK}</code>
      * (standard name <code>fl_oz_uk</code>).
      */
-    static final Unit<Volume> FLUID_OUNCE_UK = GALLON_UK.divide(160);
+    public static final Unit<Volume> FLUID_OUNCE_UK = GALLON_UK.divide(160);
 
     /**
      * A unit of volume equal to <code>1 / 160 {@link #GALLON_LIQUID}</code>

--- a/common/src/main/java/systems/uom/common/Imperial.java
+++ b/common/src/main/java/systems/uom/common/Imperial.java
@@ -134,7 +134,7 @@ public final class Imperial extends AbstractSystemOfUnits {
      * A unit of temperature equal to <code>5/9 °K</code> (standard name
      * <code>°R</code>).
      */
-    static final Unit<Temperature> RANKINE = addUnit(KELVIN.multiply(5).divide(9), "Rankine", "°R", true);
+    public static final Unit<Temperature> RANKINE = addUnit(KELVIN.multiply(5).divide(9), "Rankine", "°R", true);
 
     /**
      * A unit of temperature equal to degree Rankine minus
@@ -142,7 +142,7 @@ public final class Imperial extends AbstractSystemOfUnits {
      * 
      * @see #RANKINE
      */
-    static final Unit<Temperature> FAHRENHEIT = addUnit(RANKINE.shift(459.67), "°F", true);
+    public static final Unit<Temperature> FAHRENHEIT = addUnit(RANKINE.shift(459.67), "°F", true);
 
     //////////////
     // Time     //
@@ -151,13 +151,13 @@ public final class Imperial extends AbstractSystemOfUnits {
      * A unit of time equal to <code>60 s</code> (standard name <code>min</code>
      * ).
      */
-    static final Unit<Time> MINUTE = addUnit(SECOND.multiply(60));
+    public static final Unit<Time> MINUTE = addUnit(SECOND.multiply(60));
 
     /**
      * A unit of duration equal to <code>60 {@link #MINUTE}</code> (standard
      * name <code>h</code>).
      */
-    static final Unit<Time> HOUR = addUnit(MINUTE.multiply(60));
+    public static final Unit<Time> HOUR = addUnit(MINUTE.multiply(60));
     
     //////////
     // Area //


### PR DESCRIPTION
Some Imperial unit constants were declared with package-private
visibility, preventing external consumers from accessing them.

This change adds the missing `public` modifier to the following units:

- RANKINE
- FAHRENHEIT
- MINUTE
- HOUR
- FLUID_OUNCE_UK

These units are already fully defined and registered in the
SystemOfUnits, so exposing them does not change behavior,
only makes them accessible through the public API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/uom-systems/213)
<!-- Reviewable:end -->
